### PR TITLE
add license info to file

### DIFF
--- a/src/SyntheticDOM.js
+++ b/src/SyntheticDOM.js
@@ -1,3 +1,20 @@
+/*
+ISC License
+
+Copyright (c) 2016, Simon Sturmer <sstur@me.com>
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
 /* @flow */
 
 type Attr = {name: string; value: string};


### PR DESCRIPTION
To sstur,

Your synthetic-dom is found to be very valuable asset.
Our corporate service can deliver great value to the world with synthetic-dom.

The Git license seems to be distributed under ISC (http://opensource.org/licenses/) listed in OSI.
However, license notation can not be found in each source code of synthetic-dom.
Our service team added licnesed to file.

Your contribution is greatly appreciated.
Best Regards.